### PR TITLE
Fix `goreleaser` permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags: [ "v*" ]
 
+permissions:
+  contents: write
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest


### PR DESCRIPTION
```
The following permissions are required by GoReleaser:
`content: write` if you wish to upload archives as GitHub Releases
```
https://goreleaser.com/ci/actions/#token-permissions