### PR TITLE
Support API v4 for user management

### DIFF
--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -3,11 +3,15 @@
 * [Example](https://github.com/terraform-provider-graylog/terraform-provider-graylog/blob/master/examples/v0.12/user.tf)
 * [Source Code](https://github.com/terraform-provider-graylog/terraform-provider-graylog/blob/master/graylog/resource/user/resource.go)
 
+Please use `"v4"` version of API when using a graylog version >=4.1.
+
 ## Argument Reference
 
 * `username` - (Required, Forces new resource) The data type is `string`.
 * `email` - (Required) The data type is `string`.
-* `full_name` - (Required) The data type is `string`.
+* `full_name` - (Required for v3) The data type is `string`. For v3 api only, incompatible with `first_name` and `last_name`.
+* `first_name` - (Required for v4) The data type is `string`. For v4 api only, incompatible with `full_name`.
+* `last_name` - (Required for v4) The data type is `string`. For v4 api only, incompatible with `full_name`.
 * `password` - (Optonal, Sensitive) The data type is `string`.
 * `roles` - (Optional) The data type is `set of string`.
 * `timezone` - (Optional, Computed) The data type is `string`.

--- a/graylog/client/user/user.go
+++ b/graylog/client/user/user.go
@@ -13,16 +13,22 @@ type Client struct {
 }
 
 func (cl Client) Get(
-	ctx context.Context, name string,
+	ctx context.Context, name string, api_version string,
 ) (map[string]interface{}, *http.Response, error) {
 	if name == "" {
 		return nil, nil, errors.New("username is required")
+	}
+	var path string
+	if api_version == "v4" {
+		path = "/users/id/" + name
+	} else {
+		path = "/users/" + name
 	}
 
 	body := map[string]interface{}{}
 	resp, err := cl.Client.Call(ctx, httpclient.CallParams{
 		Method:       "GET",
-		Path:         "/users/" + name,
+		Path:         path,
 		ResponseBody: &body,
 	})
 	return body, resp, err
@@ -48,7 +54,6 @@ func (cl Client) Update(ctx context.Context, name string, user interface{}) (*ht
 	if user == nil {
 		return nil, errors.New("request body is nil")
 	}
-
 	resp, err := cl.Client.Call(ctx, httpclient.CallParams{
 		Method:      "PUT",
 		Path:        "/users/" + name,

--- a/graylog/resource/user/create.go
+++ b/graylog/resource/user/create.go
@@ -30,6 +30,7 @@ func create(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 	if cl.APIVersion == "v4" {
+		// Here we use v3 to retrieve the user information since the id is not returned by the API on creation
 		new_data, _, _ := cl.User.Get(ctx, data[keyUsername].(string), "v3")
 		d.Set("full_name", new_data["full_name"])
 		d.Set("external", new_data["external"])

--- a/graylog/resource/user/create.go
+++ b/graylog/resource/user/create.go
@@ -32,11 +32,26 @@ func create(d *schema.ResourceData, m interface{}) error {
 	if cl.APIVersion == "v4" {
 		// Here we use v3 to retrieve the user information since the id is not returned by the API on creation
 		new_data, _, _ := cl.User.Get(ctx, data[keyUsername].(string), "v3")
-		d.Set("full_name", new_data["full_name"])
-		d.Set("external", new_data["external"])
-		d.Set("permissions", new_data["permissions"])
-		d.Set("read_only", new_data["read_only"])
-		d.Set("session_active", new_data["session_active"])
+		err = d.Set("full_name", new_data["full_name"])
+		if err != nil {
+			return err
+		}
+		err = d.Set("external", new_data["external"])
+		if err != nil {
+			return err
+		}
+		err = d.Set("permissions", new_data["permissions"])
+		if err != nil {
+			return err
+		}
+		err = d.Set("read_only", new_data["read_only"])
+		if err != nil {
+			return err
+		}
+		err = d.Set("session_active", new_data["session_active"])
+		if err != nil {
+			return err
+		}
 		d.SetId(new_data["id"].(string))
 	} else {
 		d.SetId(data[keyUsername].(string))

--- a/graylog/resource/user/create.go
+++ b/graylog/resource/user/create.go
@@ -17,6 +17,9 @@ func create(d *schema.ResourceData, m interface{}) error {
 	data, err := getDataFromResourceData(d)
 	if cl.APIVersion == "v4" {
 		delete(data, "full_name")
+	} else {
+		delete(data, "first_name")
+		delete(data, "last_name")
 	}
 	if err != nil {
 		return err

--- a/graylog/resource/user/delete.go
+++ b/graylog/resource/user/delete.go
@@ -14,7 +14,13 @@ func destroy(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-	if _, err := cl.User.Delete(ctx, d.Id()); err != nil {
+	var deleted_id string
+	if cl.APIVersion == "v4" {
+		deleted_id = "id/" + d.Id()
+	} else {
+		deleted_id = d.Id()
+	}
+	if _, err := cl.User.Delete(ctx, deleted_id); err != nil {
 		return err
 	}
 	return nil

--- a/graylog/resource/user/read.go
+++ b/graylog/resource/user/read.go
@@ -15,9 +15,9 @@ func read(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-	data, resp, err := cl.User.Get(ctx, d.Id())
+	data, resp, err := cl.User.Get(ctx, d.Id(), cl.APIVersion)
 	if err != nil {
 		return util.HandleGetResourceError(d, resp, err)
 	}
-	return setDataToResourceData(d, data)
+	return setDataToResourceData(d, data, cl.APIVersion)
 }

--- a/graylog/resource/user/resource.go
+++ b/graylog/resource/user/resource.go
@@ -36,8 +36,22 @@ func Resource() *schema.Resource {
 				Required: true,
 			},
 			"full_name": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				Required:      false,
+				ConflictsWith: []string{"first_name", "last_name"},
+			},
+			"first_name": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Required:      false,
+				ConflictsWith: []string{"full_name"},
+			},
+			"last_name": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Required:      false,
+				ConflictsWith: []string{"full_name"},
 			},
 			"permissions": {
 				Type:     schema.TypeSet,

--- a/graylog/resource/user/resource.go
+++ b/graylog/resource/user/resource.go
@@ -39,6 +39,7 @@ func Resource() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Required:      false,
+				Computed:      true,
 				ConflictsWith: []string{"first_name", "last_name"},
 			},
 			"first_name": {

--- a/graylog/resource/user/update.go
+++ b/graylog/resource/user/update.go
@@ -26,6 +26,8 @@ func update(d *schema.ResourceData, m interface{}) error {
 		delete(data, "full_name")
 		update_id = d.Id()
 	} else {
+		delete(data, "first_name")
+		delete(data, "last_name")
 		update_id = oldName.(string)
 	}
 	if _, ok := data[keyPermissions]; !ok {

--- a/graylog/resource/user/update.go
+++ b/graylog/resource/user/update.go
@@ -35,7 +35,10 @@ func update(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 	if cl.APIVersion == "v4" {
-		d.Set("full_name", save_full_name)
+		err = d.Set("full_name", save_full_name)
+		if err != nil {
+			return err
+		}
 	} else {
 		d.SetId(newName.(string))
 	}

--- a/graylog/resource/user/util.go
+++ b/graylog/resource/user/util.go
@@ -22,7 +22,6 @@ func getDataFromResourceData(d *schema.ResourceData) (map[string]interface{}, er
 	if err != nil {
 		return nil, err
 	}
-
 	delete(data, keyClientAddress)
 	delete(data, keyExternal)
 	delete(data, keyLastActivity)
@@ -33,10 +32,14 @@ func getDataFromResourceData(d *schema.ResourceData) (map[string]interface{}, er
 	return data, nil
 }
 
-func setDataToResourceData(d *schema.ResourceData, data map[string]interface{}) error {
+func setDataToResourceData(d *schema.ResourceData, data map[string]interface{}, api_version string) error {
 	if err := convert.SetResourceData(d, Resource(), data); err != nil {
 		return err
 	}
-	d.SetId(data[keyUsername].(string))
+	if api_version == "v4" {
+		d.SetId(data["id"].(string))
+	} else {
+		d.SetId(data[keyUsername].(string))
+	}
 	return nil
 }


### PR DESCRIPTION
User management changed a bit with v4 of graylog-server. This PRs fixes the creation and update of user in new version while keeping old version.
I'm not a seasoned go developer, feel free to suggest enhancement